### PR TITLE
[STYLE]: (pointer argument define)

### DIFF
--- a/libs/source/wifi.c
+++ b/libs/source/wifi.c
@@ -35,12 +35,12 @@ void wifi_sendSingleByte(unsigned char cmd) {
     while((USART3->SR & 0x40) == 0);
 }
 
-void wifi_sendData(char * cmd) {
+void wifi_sendData(char *cmd) {
 	while(*cmd)
 		wifi_sendSingleByte(*cmd++);
 }
 
-void wifi_sendCmd(char * cmd) {
+void wifi_sendCmd(char *cmd) {
     wifi_sendData(cmd);
     wifi_sendSingleByte(0x0D);
     wifi_sendSingleByte(0x0A);


### PR DESCRIPTION
I realize the older version is not readable, because:
```c
int a, b;
```
 - Then you got two variables with same type.

```c
int* a, b;
```
 - In fact, you got two variables with different int type, one of them is a pointer

```c
int *a, *b;
```
As you see, this style is better!